### PR TITLE
escape space as +, not %20

### DIFF
--- a/lib/URI/Escape.pm
+++ b/lib/URI/Escape.pm
@@ -8,7 +8,7 @@ package URI::Escape {
         ;
         .chr => sprintf '%%%02X', $_
     };
-
+    %escapes{' '} = '+';
     # in moving from RFC 2396 to RFC 3986 this selection of characters
     # may be due for an update ...
 


### PR DESCRIPTION
this unbreaks fragment escaping for doc.perl6.org
